### PR TITLE
fix: resolve migration conflicts flagged in PR #113 Copilot review

### DIFF
--- a/app/Models/Work/ServicePlan.php
+++ b/app/Models/Work/ServicePlan.php
@@ -23,16 +23,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  *   ServiceJob  → executes work on each scheduled visit
  *
  * Frequency values: daily | weekly | fortnightly | monthly | quarterly | annual
- *
- * Source: ManagedPremises/Entities/PropertyServicePlan.php.
- * ServicePlan — schedule definition attached to a ServiceAgreement.
- *
- * Sits between Agreement (entitlement) and ServicePlanVisit (occurrence):
- *
- *   Agreement → ServicePlan → ServicePlanVisit → ServiceJob
- *
- * Status: active | paused | completed | cancelled
- * Frequency: daily | weekly | fortnightly | monthly | quarterly | annual | custom
+ * Status values:    active | paused | completed | cancelled
  */
 class ServicePlan extends Model
 {
@@ -49,24 +40,21 @@ class ServicePlan extends Model
         'customer_id',
         'agreement_id',
         'name',
+        'title',
         'service_type',
         'frequency',
         'interval',
+        'visits_per_cycle',
         'rrule',
         'preferred_days',
         'preferred_times',
         'starts_on',
+        'start_date',
         'ends_on',
+        'end_date',
         'next_visit_due',
         'last_visit_completed',
         'is_active',
-        'agreement_id',
-        'premises_id',
-        'title',
-        'frequency',
-        'visits_per_cycle',
-        'start_date',
-        'end_date',
         'status',
         'notes',
     ];
@@ -75,26 +63,22 @@ class ServicePlan extends Model
         'preferred_days'       => 'array',
         'preferred_times'      => 'array',
         'starts_on'            => 'date',
+        'start_date'           => 'date',
         'ends_on'              => 'date',
+        'end_date'             => 'date',
         'next_visit_due'       => 'date',
         'last_visit_completed' => 'date',
         'is_active'            => 'boolean',
         'interval'             => 'integer',
+        'visits_per_cycle'     => 'integer',
     ];
 
     protected $attributes = [
-        'frequency' => 'monthly',
-        'interval'  => 1,
-        'is_active' => true,
-        'start_date'       => 'date',
-        'end_date'         => 'date',
-        'visits_per_cycle' => 'integer',
-    ];
-
-    protected $attributes = [
-        'status'           => 'active',
         'frequency'        => 'monthly',
+        'interval'         => 1,
         'visits_per_cycle' => 1,
+        'is_active'        => true,
+        'status'           => 'active',
     ];
 
     // ── Relationships ─────────────────────────────────────────────────────────
@@ -124,14 +108,6 @@ class ServicePlan extends Model
     {
         return $this->hasMany(ServicePlanChecklist::class, 'service_plan_id')
             ->orderBy('sort_order');
-    public function premises(): BelongsTo
-    {
-        return $this->belongsTo(Premises::class, 'premises_id');
-    }
-
-    public function visits(): HasMany
-    {
-        return $this->hasMany(ServicePlanVisit::class, 'service_plan_id');
     }
 
     // ── Scopes ────────────────────────────────────────────────────────────────
@@ -172,6 +148,5 @@ class ServicePlan extends Model
 
         $this->last_visit_completed = now()->toDateString();
         $this->save();
-        return $query->where('status', 'active');
     }
 }

--- a/database/migrations/2026_04_02_000100_enhance_premises_domain.php
+++ b/database/migrations/2026_04_02_000100_enhance_premises_domain.php
@@ -77,15 +77,27 @@ return new class extends Migration {
     public function down(): void
     {
         Schema::table('premises', static function (Blueprint $table) {
-            $table->dropColumn(['service_priority', 'maintenance_zone', 'access_level']);
+            foreach (['service_priority', 'maintenance_zone', 'access_level'] as $col) {
+                if (Schema::hasColumn('premises', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
         });
 
         Schema::table('buildings', static function (Blueprint $table) {
-            $table->dropColumn(['maintenance_zone', 'year_built', 'floors_count']);
+            foreach (['maintenance_zone', 'year_built', 'floors_count'] as $col) {
+                if (Schema::hasColumn('buildings', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
         });
 
         Schema::table('premise_units', static function (Blueprint $table) {
-            $table->dropColumn(['unit_type', 'occupancy_status', 'access_level', 'service_priority', 'maintenance_zone']);
+            foreach (['unit_type', 'occupancy_status', 'access_level', 'service_priority', 'maintenance_zone'] as $col) {
+                if (Schema::hasColumn('premise_units', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
         });
     }
 };

--- a/database/migrations/2026_04_02_000400_create_inspection_domain_tables.php
+++ b/database/migrations/2026_04_02_000400_create_inspection_domain_tables.php
@@ -89,47 +89,38 @@ return new class extends Migration {
             $table->index(['company_id', 'is_active'], 'is_company_active');
         });
 
-        // ── Inspection Instances ──────────────────────────────────────────────
-        Schema::create('inspection_instances', static function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('company_id')->index();
-
-            $table->unsignedBigInteger('inspection_template_id')->nullable()->index();
-            $table->unsignedBigInteger('inspection_schedule_id')->nullable()->index();
-
-            // Scope: premises | building | unit | site_asset
-            $table->string('scope_type', 30)->nullable();
-            $table->unsignedBigInteger('scope_id')->nullable();
-
-            // Optional service job link
-            $table->unsignedBigInteger('service_job_id')->nullable()->index();
-
-            $table->string('inspection_type', 50)->nullable();
-            $table->string('title')->nullable();
-
-            $table->string('status', 30)->default('scheduled')
-                ->comment('scheduled | in_progress | completed | failed | cancelled');
-
-            $table->unsignedBigInteger('inspector_id')->nullable()->index();
-            $table->unsignedBigInteger('assigned_to')->nullable()->index();
-
-            $table->dateTime('scheduled_at')->nullable();
-            $table->dateTime('started_at')->nullable();
-            $table->dateTime('completed_at')->nullable();
-
-            $table->unsignedTinyInteger('score')->nullable();
-            $table->json('findings')->nullable();
-            $table->text('notes')->nullable();
-
-            $table->boolean('followup_required')->default(false);
-            $table->text('followup_notes')->nullable();
-
-            $table->unsignedBigInteger('created_by')->nullable()->index();
-            $table->timestamps();
-
-            $table->index(['scope_type', 'scope_id'], 'ii_scope');
-            $table->index(['company_id', 'status'], 'ii_company_status');
-            $table->index(['company_id', 'scheduled_at'], 'ii_company_scheduled');
+        // ── Inspection Instances (extend existing table from Stage J) ─────────
+        Schema::table('inspection_instances', static function (Blueprint $table) {
+            if (! Schema::hasColumn('inspection_instances', 'inspection_template_id')) {
+                $table->unsignedBigInteger('inspection_template_id')->nullable()->index()->after('company_id');
+            }
+            if (! Schema::hasColumn('inspection_instances', 'inspection_schedule_id')) {
+                $table->unsignedBigInteger('inspection_schedule_id')->nullable()->index()->after('inspection_template_id');
+            }
+            if (! Schema::hasColumn('inspection_instances', 'scope_type')) {
+                $table->string('scope_type', 30)->nullable()->after('inspection_schedule_id');
+            }
+            if (! Schema::hasColumn('inspection_instances', 'scope_id')) {
+                $table->unsignedBigInteger('scope_id')->nullable()->after('scope_type');
+            }
+            if (! Schema::hasColumn('inspection_instances', 'inspector_id')) {
+                $table->unsignedBigInteger('inspector_id')->nullable()->index()->after('assigned_to');
+            }
+            if (! Schema::hasColumn('inspection_instances', 'started_at')) {
+                $table->dateTime('started_at')->nullable()->after('scheduled_at');
+            }
+            if (! Schema::hasColumn('inspection_instances', 'score')) {
+                $table->unsignedTinyInteger('score')->nullable()->after('completed_at');
+            }
+            if (! Schema::hasColumn('inspection_instances', 'findings')) {
+                $table->json('findings')->nullable()->after('score');
+            }
+            if (! Schema::hasColumn('inspection_instances', 'followup_required')) {
+                $table->boolean('followup_required')->default(false)->after('notes');
+            }
+            if (! Schema::hasColumn('inspection_instances', 'followup_notes')) {
+                $table->text('followup_notes')->nullable()->after('followup_required');
+            }
         });
 
         // ── Inspection Items (per-instance line items) ────────────────────────
@@ -204,9 +195,21 @@ return new class extends Migration {
         Schema::dropIfExists('inspection_attachments');
         Schema::dropIfExists('inspection_responses');
         Schema::dropIfExists('inspection_items');
-        Schema::dropIfExists('inspection_instances');
         Schema::dropIfExists('inspection_schedules');
         Schema::dropIfExists('inspection_template_items');
         Schema::dropIfExists('inspection_templates');
+
+        // Remove extended columns from inspection_instances (do not drop the table itself)
+        Schema::table('inspection_instances', static function (Blueprint $table) {
+            $cols = [
+                'inspection_template_id', 'inspection_schedule_id', 'scope_type', 'scope_id',
+                'inspector_id', 'started_at', 'score', 'findings', 'followup_required', 'followup_notes',
+            ];
+            foreach ($cols as $col) {
+                if (Schema::hasColumn('inspection_instances', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
     }
 };

--- a/database/migrations/2026_04_02_000500_create_checklist_framework_tables.php
+++ b/database/migrations/2026_04_02_000500_create_checklist_framework_tables.php
@@ -59,30 +59,23 @@ return new class extends Migration {
                 ->references('id')->on('checklist_templates')->onDelete('cascade');
         });
 
-        // ── Checklist Runs ────────────────────────────────────────────────────
-        Schema::create('checklist_runs', static function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('company_id')->index();
-            $table->unsignedBigInteger('checklist_template_id')->nullable()->index();
-
-            // Polymorphic context: service_job | inspection_instance | premises
-            $table->string('runnable_type', 60)->nullable();
-            $table->unsignedBigInteger('runnable_id')->nullable();
-
-            $table->string('title')->nullable();
-            $table->string('status', 30)->default('pending')
-                ->comment('pending | in_progress | completed | skipped');
-
-            $table->unsignedBigInteger('assigned_to')->nullable()->index();
-            $table->timestamp('started_at')->nullable();
-            $table->timestamp('completed_at')->nullable();
-            $table->text('notes')->nullable();
-
-            $table->unsignedBigInteger('created_by')->nullable()->index();
-            $table->timestamps();
-
-            $table->index(['runnable_type', 'runnable_id'], 'cr_runnable');
-            $table->index(['company_id', 'status'], 'cr_company_status');
+        // ── Checklist Runs (extend existing table from Stage J) ───────────────
+        Schema::table('checklist_runs', static function (Blueprint $table) {
+            if (! Schema::hasColumn('checklist_runs', 'checklist_template_id')) {
+                $table->unsignedBigInteger('checklist_template_id')->nullable()->index()->after('company_id');
+            }
+            if (! Schema::hasColumn('checklist_runs', 'runnable_type')) {
+                $table->string('runnable_type', 60)->nullable()->after('checklist_template_id');
+            }
+            if (! Schema::hasColumn('checklist_runs', 'runnable_id')) {
+                $table->unsignedBigInteger('runnable_id')->nullable()->after('runnable_type');
+            }
+            if (! Schema::hasColumn('checklist_runs', 'assigned_to')) {
+                $table->unsignedBigInteger('assigned_to')->nullable()->index()->after('status');
+            }
+            if (! Schema::hasColumn('checklist_runs', 'notes')) {
+                $table->text('notes')->nullable()->after('assigned_to');
+            }
         });
 
         // ── Checklist Responses ───────────────────────────────────────────────
@@ -115,8 +108,16 @@ return new class extends Migration {
     public function down(): void
     {
         Schema::dropIfExists('checklist_responses');
-        Schema::dropIfExists('checklist_runs');
         Schema::dropIfExists('checklist_items');
         Schema::dropIfExists('checklist_templates');
+
+        // Remove extended columns from checklist_runs (do not drop the table itself)
+        Schema::table('checklist_runs', static function (Blueprint $table) {
+            foreach (['checklist_template_id', 'runnable_type', 'runnable_id', 'assigned_to', 'notes'] as $col) {
+                if (Schema::hasColumn('checklist_runs', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
     }
 };

--- a/database/migrations/2026_04_02_000600_create_site_asset_tables.php
+++ b/database/migrations/2026_04_02_000600_create_site_asset_tables.php
@@ -23,55 +23,49 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-        // ── Site Assets ───────────────────────────────────────────────────────
-        Schema::create('site_assets', static function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('company_id')->index();
-
-            // Hierarchy linkage
-            $table->unsignedBigInteger('premises_id')->nullable()->index();
-            $table->unsignedBigInteger('building_id')->nullable()->index();
-            $table->unsignedBigInteger('unit_id')->nullable()->index();
-
-            // Link to Equipment catalogue (optional — may be a bespoke install)
-            $table->unsignedBigInteger('equipment_id')->nullable()->index();
-
-            $table->string('label');
-            $table->string('asset_code')->nullable()->index();
-            $table->string('asset_type', 80)->nullable()
-                ->comment('e.g. hvac | pump | fire_panel | alarm | access_control | meter | other');
-            $table->string('manufacturer')->nullable();
-            $table->string('model_number')->nullable();
-            $table->string('serial_number')->nullable();
-            $table->string('location_description')->nullable();
-
-            // Lifecycle
-            $table->date('install_date')->nullable();
-            $table->date('commission_date')->nullable();
-            $table->date('warranty_expiry')->nullable();
-            $table->unsignedSmallInteger('inspection_interval_days')->nullable()
-                ->comment('Days between required inspections');
-            $table->unsignedSmallInteger('maintenance_interval_days')->nullable()
-                ->comment('Days between preventive maintenance visits');
-            $table->date('next_inspection_due')->nullable();
-            $table->date('next_maintenance_due')->nullable();
-            $table->date('last_serviced_at')->nullable();
-
-            $table->string('condition_status', 30)->default('good')
-                ->comment('new | good | fair | poor | decommissioned');
-
-            $table->string('status', 30)->default('active')
-                ->comment('active | removed | replaced | decommissioned');
-
-            $table->text('notes')->nullable();
-            $table->json('meta')->nullable();
-
-            $table->unsignedBigInteger('created_by')->nullable()->index();
-            $table->timestamps();
-            $table->softDeletes();
-
-            $table->index(['company_id', 'status'], 'sa_company_status');
-            $table->index(['company_id', 'premises_id'], 'sa_company_premises');
+        // ── Site Assets (extend existing table from Stage I) ──────────────────
+        Schema::table('site_assets', static function (Blueprint $table) {
+            if (! Schema::hasColumn('site_assets', 'equipment_id')) {
+                $table->unsignedBigInteger('equipment_id')->nullable()->index()->after('unit_id');
+            }
+            if (! Schema::hasColumn('site_assets', 'label')) {
+                $table->string('label')->nullable()->after('equipment_id');
+            }
+            if (! Schema::hasColumn('site_assets', 'asset_type')) {
+                $table->string('asset_type', 80)->nullable()
+                    ->comment('hvac | pump | fire_panel | alarm | access_control | meter | other')
+                    ->after('label');
+            }
+            if (! Schema::hasColumn('site_assets', 'model_number')) {
+                $table->string('model_number')->nullable()->after('manufacturer');
+            }
+            if (! Schema::hasColumn('site_assets', 'commission_date')) {
+                $table->date('commission_date')->nullable()->after('install_date');
+            }
+            if (! Schema::hasColumn('site_assets', 'inspection_interval_days')) {
+                $table->unsignedSmallInteger('inspection_interval_days')->nullable()
+                    ->comment('Days between required inspections')->after('warranty_expiry');
+            }
+            if (! Schema::hasColumn('site_assets', 'maintenance_interval_days')) {
+                $table->unsignedSmallInteger('maintenance_interval_days')->nullable()
+                    ->comment('Days between preventive maintenance visits')->after('inspection_interval_days');
+            }
+            if (! Schema::hasColumn('site_assets', 'next_inspection_due')) {
+                $table->date('next_inspection_due')->nullable()->after('maintenance_interval_days');
+            }
+            if (! Schema::hasColumn('site_assets', 'next_maintenance_due')) {
+                $table->date('next_maintenance_due')->nullable()->after('next_inspection_due');
+            }
+            if (! Schema::hasColumn('site_assets', 'last_serviced_at')) {
+                $table->date('last_serviced_at')->nullable()->after('next_maintenance_due');
+            }
+            if (! Schema::hasColumn('site_assets', 'condition_status')) {
+                $table->string('condition_status', 30)->default('good')
+                    ->comment('new | good | fair | poor | decommissioned')->after('last_serviced_at');
+            }
+            if (! Schema::hasColumn('site_assets', 'meta')) {
+                $table->json('meta')->nullable()->after('notes');
+            }
         });
 
         // ── Asset Service Events ──────────────────────────────────────────────
@@ -108,6 +102,20 @@ return new class extends Migration {
     public function down(): void
     {
         Schema::dropIfExists('asset_service_events');
-        Schema::dropIfExists('site_assets');
+
+        // Remove extended columns only — do not drop site_assets itself
+        Schema::table('site_assets', static function (Blueprint $table) {
+            $cols = [
+                'equipment_id', 'label', 'asset_type', 'model_number',
+                'commission_date', 'inspection_interval_days', 'maintenance_interval_days',
+                'next_inspection_due', 'next_maintenance_due', 'last_serviced_at',
+                'condition_status', 'meta',
+            ];
+            foreach ($cols as $col) {
+                if (Schema::hasColumn('site_assets', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
     }
 };

--- a/database/migrations/2026_04_02_000800_create_service_plan_tables.php
+++ b/database/migrations/2026_04_02_000800_create_service_plan_tables.php
@@ -7,16 +7,11 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 /**
- * Stage E — Service Plan Domain
+ * Stage E — Service Plan Domain (extension pass)
  *
- * Recurring service configuration separate from agreements.
- * Agreement → defines entitlement
- * ServicePlan → defines schedule / visits
- * ServiceJob → executes work
- *
- *   service_plans           — plan configuration per premises/customer
- *   service_plan_visits     — individual planned visits (can generate a ServiceJob)
- *   service_plan_checklists — checklist templates injected into each visit
+ * Extends the service_plans and service_plan_visits tables created in
+ * 000100_create_service_plan_tables.php with richer scheduling fields.
+ * Also creates service_plan_checklists which is new.
  *
  * Sources: ManagedPremises/Entities/PropertyServicePlan.php,
  *          ManagedPremises/Entities/PropertyVisit.php.
@@ -24,99 +19,105 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-        // ── Service Plans ─────────────────────────────────────────────────────
-        Schema::create('service_plans', static function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('company_id')->index();
-
-            $table->unsignedBigInteger('premises_id')->nullable()->index();
-            $table->unsignedBigInteger('customer_id')->nullable()->index();
-
-            // Optional agreement linkage (Agreement defines entitlement)
-            $table->unsignedBigInteger('agreement_id')->nullable()->index();
-
-            $table->string('name');
-            $table->string('service_type', 80)->nullable()
-                ->comment('e.g. cleaning | inspection | maintenance | pest_control');
-
-            // Recurrence
-            $table->string('frequency', 30)->default('monthly')
-                ->comment('daily | weekly | fortnightly | monthly | quarterly | annual');
-            $table->unsignedSmallInteger('interval')->default(1);
-            $table->string('rrule')->nullable()
-                ->comment('RFC5545 RRULE for complex schedules');
-            $table->json('preferred_days')->nullable();
-            $table->json('preferred_times')->nullable();
-
-            $table->date('starts_on')->nullable();
-            $table->date('ends_on')->nullable();
-            $table->date('next_visit_due')->nullable()->index();
-            $table->date('last_visit_completed')->nullable();
-
-            $table->boolean('is_active')->default(true);
-            $table->text('notes')->nullable();
-
-            $table->unsignedBigInteger('created_by')->nullable()->index();
-            $table->timestamps();
-
-            $table->index(['company_id', 'is_active'], 'sp_company_active');
+        // ── Extend service_plans with richer scheduling fields ────────────────
+        Schema::table('service_plans', static function (Blueprint $table) {
+            if (! Schema::hasColumn('service_plans', 'customer_id')) {
+                $table->unsignedBigInteger('customer_id')->nullable()->index()->after('premises_id');
+            }
+            if (! Schema::hasColumn('service_plans', 'name')) {
+                $table->string('name')->nullable()->after('customer_id');
+            }
+            if (! Schema::hasColumn('service_plans', 'service_type')) {
+                $table->string('service_type', 80)->nullable()
+                    ->comment('cleaning | inspection | maintenance | pest_control')
+                    ->after('name');
+            }
+            if (! Schema::hasColumn('service_plans', 'interval')) {
+                $table->unsignedSmallInteger('interval')->default(1)->after('frequency');
+            }
+            if (! Schema::hasColumn('service_plans', 'rrule')) {
+                $table->string('rrule')->nullable()
+                    ->comment('RFC5545 RRULE for complex schedules')->after('interval');
+            }
+            if (! Schema::hasColumn('service_plans', 'preferred_days')) {
+                $table->json('preferred_days')->nullable()->after('rrule');
+            }
+            if (! Schema::hasColumn('service_plans', 'preferred_times')) {
+                $table->json('preferred_times')->nullable()->after('preferred_days');
+            }
+            if (! Schema::hasColumn('service_plans', 'starts_on')) {
+                $table->date('starts_on')->nullable()->after('preferred_times');
+            }
+            if (! Schema::hasColumn('service_plans', 'ends_on')) {
+                $table->date('ends_on')->nullable()->after('starts_on');
+            }
+            if (! Schema::hasColumn('service_plans', 'next_visit_due')) {
+                $table->date('next_visit_due')->nullable()->index()->after('ends_on');
+            }
+            if (! Schema::hasColumn('service_plans', 'last_visit_completed')) {
+                $table->date('last_visit_completed')->nullable()->after('next_visit_due');
+            }
+            if (! Schema::hasColumn('service_plans', 'is_active')) {
+                $table->boolean('is_active')->default(true)->after('last_visit_completed');
+            }
         });
 
-        // ── Service Plan Visits ───────────────────────────────────────────────
-        Schema::create('service_plan_visits', static function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('company_id')->index();
-            $table->unsignedBigInteger('service_plan_id')->index();
-
-            // Generated ServiceJob (populated when the visit converts to a job)
-            $table->unsignedBigInteger('service_job_id')->nullable()->index();
-
-            $table->string('visit_type', 60)->nullable()
-                ->comment('service | inspection | maintenance | key_handover');
-            $table->dateTime('scheduled_for')->nullable();
-            $table->unsignedBigInteger('assigned_to')->nullable()->index();
-
-            $table->string('status', 30)->default('scheduled')
-                ->comment('scheduled | confirmed | in_progress | completed | cancelled | no_access');
-
-            $table->dateTime('completed_at')->nullable();
-            $table->text('notes')->nullable();
-
-            $table->unsignedBigInteger('created_by')->nullable()->index();
-            $table->timestamps();
-
-            $table->foreign('service_plan_id')
-                ->references('id')->on('service_plans')->onDelete('cascade');
-            $table->index(['company_id', 'status'], 'spv_company_status');
-            $table->index(['company_id', 'scheduled_for'], 'spv_company_scheduled');
+        // ── Extend service_plan_visits with richer visit fields ───────────────
+        Schema::table('service_plan_visits', static function (Blueprint $table) {
+            if (! Schema::hasColumn('service_plan_visits', 'visit_type')) {
+                $table->string('visit_type', 60)->nullable()
+                    ->comment('service | inspection | maintenance | key_handover')
+                    ->after('service_job_id');
+            }
+            if (! Schema::hasColumn('service_plan_visits', 'assigned_to')) {
+                $table->unsignedBigInteger('assigned_to')->nullable()->index()->after('visit_type');
+            }
+            if (! Schema::hasColumn('service_plan_visits', 'scheduled_for')) {
+                $table->dateTime('scheduled_for')->nullable()->after('assigned_to');
+            }
         });
 
-        // ── Service Plan Checklists ───────────────────────────────────────────
-        Schema::create('service_plan_checklists', static function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('service_plan_id')->index();
+        // ── Service Plan Checklists (new table) ───────────────────────────────
+        if (! Schema::hasTable('service_plan_checklists')) {
+            Schema::create('service_plan_checklists', static function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('service_plan_id')->index();
+                $table->unsignedBigInteger('checklist_template_id')->nullable()->index();
+                $table->unsignedBigInteger('inspection_template_id')->nullable()->index();
+                $table->string('label')->nullable();
+                $table->boolean('is_active')->default(true);
+                $table->unsignedSmallInteger('sort_order')->default(0);
+                $table->timestamps();
 
-            // Checklist template to inject into each generated visit / job
-            $table->unsignedBigInteger('checklist_template_id')->nullable()->index();
-
-            // Optional inspection template to inject
-            $table->unsignedBigInteger('inspection_template_id')->nullable()->index();
-
-            $table->string('label')->nullable();
-            $table->boolean('is_active')->default(true);
-            $table->unsignedSmallInteger('sort_order')->default(0);
-
-            $table->timestamps();
-
-            $table->foreign('service_plan_id')
-                ->references('id')->on('service_plans')->onDelete('cascade');
-        });
+                $table->foreign('service_plan_id')
+                    ->references('id')->on('service_plans')->onDelete('cascade');
+            });
+        }
     }
 
     public function down(): void
     {
         Schema::dropIfExists('service_plan_checklists');
-        Schema::dropIfExists('service_plan_visits');
-        Schema::dropIfExists('service_plans');
+
+        Schema::table('service_plan_visits', static function (Blueprint $table) {
+            foreach (['visit_type', 'assigned_to', 'scheduled_for'] as $col) {
+                if (Schema::hasColumn('service_plan_visits', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+
+        Schema::table('service_plans', static function (Blueprint $table) {
+            $cols = [
+                'customer_id', 'name', 'service_type', 'interval', 'rrule',
+                'preferred_days', 'preferred_times', 'starts_on', 'ends_on',
+                'next_visit_due', 'last_visit_completed', 'is_active',
+            ];
+            foreach ($cols as $col) {
+                if (Schema::hasColumn('service_plans', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
     }
 };


### PR DESCRIPTION
- 000800_create_service_plan_tables: rewrite as ALTER pass (service_plans and service_plan_visits already exist from 000100); adds missing columns and creates new service_plan_checklists table

- 000400_create_inspection_domain_tables: change inspection_instances block from Schema::create to Schema::table (table already created by Stage J); extends with template_id, schedule_id, scope, inspector, score, findings, followup fields; down() removes columns without dropping the table

- 000500_create_checklist_framework_tables: change checklist_runs block from Schema::create to Schema::table (table already created by Stage J); adds checklist_template_id, runnable_type/id, assigned_to, notes; down() removes columns without dropping the table

- 000600_create_site_asset_tables: change site_assets block from Schema::create to Schema::table (table already created by Stage I); adds lifecycle fields (equipment_id, label, asset_type, model_number, commission_date, interval_days, condition_status, meta); asset_service_events created normally as it is new

- 000100_enhance_premises_domain: add Schema::hasColumn guards to down() so rollback is safe when columns were never added

- ServicePlan model: remove duplicate $fillable keys, duplicate $attributes blocks, duplicate relationship methods, and fix broken closing brace

https://claude.ai/code/session_01GR7nZxTDeuLErgEshE9iSq